### PR TITLE
fix: 修复 max_results 失效、Slice_t 泄漏与多处 core dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@
 npm install wework-chat-node
 ```
 
-如果需要升级企业微信 SDK,请更新 lib/libWeWorkFinanceSdk_C.so 以及 include/wework/WeWorkFinanceSdk_C.h，文件更新后再 build。
+如果需要升级企业微信 SDK,请按架构更新 `lib/x86/libWeWorkFinanceSdk_C.so`（或 `lib/arm/`）以及对应的
+`include/wework/x86/WeWorkFinanceSdk_C.h`（或 `include/wework/arm/`），文件更新后再 build。
 本模块也会持续更新优化。
 
 ##### Compiling
 
-由于企业微信提供的 sdk 仅支持 linux 与 windows,在 OS X 下可编译成功，但无法正常使用。
+企业微信只提供了 Linux 版的 `.so`，所以本模块只能在 Linux 下运行。`npm install` 里的编译步骤已经做了平台判断，
+在 macOS / Windows 上会跳过 `node-gyp rebuild`，安装本身不会失败，但也无法调用。本地开发建议直接用 Docker
+（README 顶部的 node slim 镜像即可）。
 
 ### Example
 
@@ -88,5 +91,48 @@ const test = () => {
 
 test();
 ```
+
+### 常见问题
+
+##### Segmentation fault (core dumped)
+
+已知会导致 core dump 的几种情况都已在 v1.2.1 修掉，如果仍然遇到，请先确认升级到最新版本：
+
+- `stopFetch()` 之前会在 800ms 后就 `DestroySdk`，而一次 `GetChatData` 最长要等 30s，
+  后台线程会继续使用已经被释放的 sdk。现在 `stopFetch()` 会等后台线程真正退出再释放。
+- 重复调用 `stopFetch()` 会把 sdk double free，现在只会释放一次。
+- 服务端返回的 JSON 缺字段（例如没有 `chatdata`）时，rapidjson 在 Release 构建下不做成员检查，
+  会直接野指针解引用。现在所有字段读取都走存在性判断。
+- 参数类型不对（比如 `getChatData()` 不传对象）时，抛出的 JS 异常并不会中断 C++ 执行流，
+  下一行就会把非对象当对象用。现在这些分支都会立即返回。
+- `new WeWorkChat()` 初始化失败后继续调用其它方法，现在会抛出明确的错误而不是崩溃。
+
+##### 怎么拿到最终的 seq
+
+两种方式：
+
+- `stopFetch()` 的返回值。它会阻塞等待后台线程退出（最长 45s）后再返回，
+  所以拿到的是本次 fetch 真正处理完的最后一个 seq。
+- `getChatData()` 返回的 `last_seq`，即本批最后一条消息的 seq。
+  注意本批为空时 `last_seq` 是 `0`，轮询时请自行保留上一次的 seq，不要无条件赋值回去：
+
+```javascript
+let seq = 0;
+while (true) {
+	const ret = wework.getChatData({ max_results: 1000, timeout: 30, seq });
+	if (!ret.data.length) break;
+	seq = ret.last_seq; // 只在有数据时推进
+	// ... 处理 ret.data
+}
+```
+
+生产环境建议每处理完一条就把 seq 落库/写 Redis，重启后从落库的 seq 继续；
+或者允许少量重复，接收端按 `msgid` 去重。
+
+##### 消息解密失败 / 拿到的 data 里有空值
+
+解密失败最常见的原因是私钥版本对不上。企业微信允许存在多个版本的密钥，每条消息的
+`publickey_ver` 指明它该用哪个版本的私钥解密。现在解密失败时会打印该条消息的 `seq` 和
+`publickey_ver`，按提示换成对应版本的私钥即可。解密失败的消息在 `data` 里会留空，遍历时请跳过。
 
 ### TO DO

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,10 @@
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
-      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+      "defines": [
+        "NAPI_DISABLE_CPP_EXCEPTIONS",
+        "OPENSSL_API_COMPAT=0x10100000L"
+      ],
       "conditions": [
         ["target_arch=='arm64'", {
           "libraries": [ "<(module_root_dir)/lib/arm/libWeWorkFinanceSdk_C.so" ],

--- a/include/wework/wework.h
+++ b/include/wework/wework.h
@@ -2,14 +2,17 @@
 #define WEWORKCHAT_H
 
 #include <napi.h>
+#include <atomic>
+#include <string>
 #include <thread>
 
 #include "WeWorkFinanceSdk_C.h"
 
+class WeWorkChat;
 
 struct TsfnContext {
   TsfnContext(Napi::Env env) : deferred(Napi::Promise::Deferred::New(env)) {
-    
+
   };
   // Native Promise returned to JavaScript
   Napi::Promise::Deferred deferred;
@@ -18,6 +21,9 @@ struct TsfnContext {
   std::thread nativeThread;
 
   Napi::ThreadSafeFunction tsfn;
+
+  // 发起 fetch 的实例，Finalizer 里用它解除对 JS 对象的强引用
+  WeWorkChat *owner = nullptr;
 };
 
 struct MsgData {
@@ -30,33 +36,40 @@ class WeWorkChat : public Napi::ObjectWrap<WeWorkChat>{
  public:
   static Napi::Object Init(Napi::Env env, Napi::Object exports);
     WeWorkChat(const Napi::CallbackInfo& info);
+    ~WeWorkChat();
 
-    
+    // fetch 线程退出、tsfn 销毁后由 FinalizerCallback 调用
+    void ReleaseFetchRef();
+
  private:
-    
+
     Napi::Value EndFetchData(const Napi::CallbackInfo& info);
     Napi::Value StartFetchData(const Napi::CallbackInfo& info);
     Napi::Value GetMediaData(const Napi::CallbackInfo& info);
     Napi::Value GetChat(const Napi::CallbackInfo& info);
-        
+
     int64_t parseJsonData(TsfnContext *context,const char *data);
     static void* fetchData(TsfnContext *context,void *arg);
-  
+
     int initSdk(const Napi::CallbackInfo& info);
-    
-    
+    // sdk 可用性检查：init 失败或 stopFetch 释放之后再调用底层接口会直接崩溃
+    bool ensureSdk(Napi::Env env);
+    // 释放 sdk，重复调用只生效一次，避免 double free
+    void destroySdk();
+
+
     std::string corpid_;
     std::string secret_;
     WeWorkFinanceSdk_t *sdk_;
-    std::mutex mtx_;
     std::string private_key_;
-    int64_t seq_;
-    bool end_;
+    std::atomic<int64_t> seq_;
+    std::atomic<bool> end_;
+    // fetch 线程是否还在运行，stopFetch 靠它判断何时可以安全释放 sdk
+    std::atomic<bool> fetching_;
+    std::atomic<bool> sdk_destroyed_;
 };
 
 
 std::string decode64(const std::string &ascdata);
 std::string rsa_pri_decrypt(const std::string &cipherText, const char *priKey);
 #endif
-
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,18 +10,18 @@ export interface InitParams {
 }
 
 export interface GetDataParams {
-	/** 返回条数，最大1000 */
-	max_results: number;
-	/** 超时时间 单位 s */
-	timeout: number;
-	/** 数据拉取index */
-	seq: number;
+	/** 返回条数，最大 1000。不传或超出 1~1000 时按 1000 处理 */
+	max_results?: number;
+	/** 超时时间 单位 s，不传默认 30 */
+	timeout?: number;
+	/** 数据拉取 index，从该 seq 之后开始拉取。不传默认 0 */
+	seq?: number;
 }
 
 export interface GetMediaDataParams {
 	/** 媒体资源的id信息 */
 	sdk_fileid: string;
-	/**媒体消息分片拉取，需要填入每次拉取的索引信息 */
+	/** 媒体消息分片拉取，需要填入每次拉取的索引信息。首次拉取可不传 */
 	index_buf?: string;
 }
 
@@ -177,9 +177,16 @@ export interface ChatDataItem {
 }
 
 export interface ChatDataResp {
-	/** 最后一条数据的 seq */
+	/**
+	 * 本批最后一条数据的 seq。
+	 * 本批没有数据时为 0，轮询时请自行保留上一次的 seq，不要直接赋值回去。
+	 */
 	last_seq: number;
-	data: string[];
+	/**
+	 * 解密后的消息 JSON 字符串数组，每一项可用 JSON.parse 得到 ChatDataItem。
+	 * 私钥版本不匹配等原因导致解密失败的消息会留空，遍历时请跳过空值。
+	 */
+	data: (string | undefined)[];
 }
 
 export interface CallbackFunc {
@@ -187,7 +194,23 @@ export interface CallbackFunc {
 }
 export interface WeWorkChat {
 	getMediaData(params: GetMediaDataParams): MediaDataResp;
-	fetchData(fn: CallbackFunc): any;
+	/**
+	 * 回调形式：成功时回调 (null, resp) 并返回 null；失败时回调 (errMsg) 并返回 -1。
+	 */
+	getMediaData(
+		params: GetMediaDataParams,
+		cb: (err: string | null, resp?: MediaDataResp) => void
+	): null | number;
+	/**
+	 * 启动后台线程持续拉取消息，每条消息回调一次。
+	 * 同一实例同时只能有一个 fetchData 在跑，返回的 Promise 在 stopFetch 之后 resolve。
+	 */
+	fetchData(fn: CallbackFunc): Promise<boolean>;
+	/**
+	 * 停止 fetchData 并释放 sdk，返回停止时已拉取到的最后一个 seq。
+	 * 会阻塞等待后台线程真正退出（最长 45s），以保证返回的 seq 是最终值、
+	 * 且 sdk 不会在使用中被释放。调用之后该实例不能再发起请求。
+	 */
 	stopFetch(): number;
 	getChatData(params: GetDataParams): ChatDataResp;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wework-chat-node",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wework-chat-node",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wework-chat-node",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "WeWorkFinanceSdk node c++ addon",
   "main": "index.js",
   "gypfile": false,

--- a/wework.cc
+++ b/wework.cc
@@ -5,9 +5,9 @@
 
 #include <limits>
 #include <thread>
-#include <mutex>
 #include <chrono>
 
+#include <cmath>
 #include <stdexcept>
 #include <cctype>
 #include "openssl/md5.h"
@@ -38,12 +38,6 @@
 using namespace std;
 using namespace rapidjson;
 
-//WeWorkFinanceSdk_t *WeWorkChat::sdk_;
-//std::string WeWorkChat::private_key_;
-//int64_t WeWorkChat::seq_;
-//bool WeWorkChat::end_;
-//std::mutex WeWorkChat::mtx_;
-
 std::string ERROR_PREFIX = "WEWORK_CHAT_NODE::";
 
 //// thread/////
@@ -55,6 +49,11 @@ void FinalizerCallback(Napi::Env env, void *finalizeData,
                        TsfnContext *context) {
   // Join the thread
   context->nativeThread.join();
+
+  // fetch 期间对 JS 对象加了强引用，线程结束后必须解除，否则实例永远不会被回收
+  if (context->owner != nullptr) {
+    context->owner->ReleaseFetchRef();
+  }
 
   // Resolve the Promise previously returned to JS via the CreateTSFN method.
   context->deferred.Resolve(Napi::Boolean::New(env, true));
@@ -78,7 +77,122 @@ static const char reverse_table[128] = {
    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64
 };
 
-const int max_results = 1000;
+// 企业微信单次拉取上限，超过 1000 服务端会直接返回错误
+const int kMaxResults = 1000;
+// getChatData 未传 timeout 时的默认超时（秒）
+const int kDefaultTimeout = 30;
+// fetchData 后台轮询的超时（秒）
+const int kFetchTimeout = 30;
+// stopFetch 等待后台线程退出的上限（毫秒）
+const int kStopWaitMs = 45000;
+
+namespace {
+
+// NewSlice 分配的 Slice_t 必须配对 FreeSlice。之前每个 return / continue 分支
+// 都要手写一次 FreeSlice，只要漏掉一个就会泄漏，改成 RAII 之后任何出口都不会漏。
+class SliceGuard {
+public:
+    SliceGuard() : slice_(NewSlice()) {}
+    ~SliceGuard() { reset(); }
+    SliceGuard(const SliceGuard &) = delete;
+    SliceGuard &operator=(const SliceGuard &) = delete;
+
+    Slice_t *get() const { return slice_; }
+    bool valid() const { return slice_ != nullptr; }
+    // 把所有权交出去（例如交给 ThreadSafeFunction 回调负责释放）
+    Slice_t *release() {
+        Slice_t *s = slice_;
+        slice_ = nullptr;
+        return s;
+    }
+    void reset() {
+        if (slice_ != nullptr) {
+            FreeSlice(slice_);
+            slice_ = nullptr;
+        }
+    }
+
+private:
+    Slice_t *slice_;
+};
+
+// rapidjson 在 NDEBUG（Release 构建）下 operator[] 不做成员存在性检查，
+// 服务端一旦少返回一个字段就是野指针解引用，直接 Segmentation fault。
+// 下面几个 helper 统一走 FindMember，缺字段时返回默认值。
+const rapidjson::Value *FindMember(const rapidjson::Value &v, const char *name) {
+    if (!v.IsObject()) {
+        return nullptr;
+    }
+    rapidjson::Value::ConstMemberIterator it = v.FindMember(name);
+    if (it == v.MemberEnd()) {
+        return nullptr;
+    }
+    return &it->value;
+}
+
+const char *GetStringMember(const rapidjson::Value &v, const char *name, const char *fallback) {
+    const rapidjson::Value *m = FindMember(v, name);
+    if (m == nullptr || !m->IsString()) {
+        return fallback;
+    }
+    return m->GetString();
+}
+
+int64_t GetInt64Member(const rapidjson::Value &v, const char *name, int64_t fallback) {
+    const rapidjson::Value *m = FindMember(v, name);
+    if (m == nullptr) {
+        return fallback;
+    }
+    if (m->IsInt64()) {
+        return m->GetInt64();
+    }
+    if (m->IsUint64()) {
+        return static_cast<int64_t>(m->GetUint64());
+    }
+    return fallback;
+}
+
+// 读取数值参数：字段缺失 / 不是数字 / NaN 时都退回默认值。
+// 直接 ToNumber() 拿 undefined 会得到 NaN，转成 int64_t 是未定义行为。
+int64_t GetNumberOption(const Napi::Object &obj, const char *key, int64_t fallback) {
+    if (!obj.Has(key)) {
+        return fallback;
+    }
+    Napi::Value v = obj.Get(key);
+    if (!v.IsNumber()) {
+        return fallback;
+    }
+    double d = v.As<Napi::Number>().DoubleValue();
+    if (std::isnan(d)) {
+        return fallback;
+    }
+    return static_cast<int64_t>(d);
+}
+
+// 读取字符串参数：字段缺失时返回 fallback。
+// 直接 ToString() 拿 undefined 会得到字面量 "undefined" 并被当成真实参数传给 sdk。
+std::string GetStringOption(const Napi::Object &obj, const char *key, const char *fallback) {
+    if (!obj.Has(key)) {
+        return fallback;
+    }
+    Napi::Value v = obj.Get(key);
+    if (v.IsUndefined() || v.IsNull()) {
+        return fallback;
+    }
+    return v.ToString().Utf8Value();
+}
+
+// 解密失败最常见的原因是私钥版本对不上，publickey_ver 指明这条消息该用哪个版本的私钥。
+// 注意只打印版本号，不要把 private_key 打进日志。
+void LogDecryptKeyFailure(const rapidjson::Value &item) {
+    printf("%sdecrypt encrypt_random_key failed, seq:%lld publickey_ver:%lld, "
+           "请确认 private_key 是该 publickey_ver 对应版本的私钥\n",
+           ERROR_PREFIX.c_str(),
+           static_cast<long long>(GetInt64Member(item, "seq", -1)),
+           static_cast<long long>(GetInt64Member(item, "publickey_ver", -1)));
+}
+
+}  // namespace
 
 Napi::Object WeWorkChat::Init(Napi::Env env, Napi::Object exports) {
   Napi::Function func =
@@ -102,10 +216,20 @@ int WeWorkChat::initSdk(const Napi::CallbackInfo& info){
     int ret = 0;
     // new sdk api
     this->sdk_ = ::NewSdk();
+    if (this->sdk_ == nullptr) {
+        printf("%sNewSdk returned null\n", ERROR_PREFIX.c_str());
+        Napi::TypeError::New(info.Env(), "Create WeWorkFinance sdk error.")
+            .ThrowAsJavaScriptException();
+        return -1;
+    }
     ret = ::Init(this->sdk_, this->corpid_.c_str(), this->secret_.c_str());
     if (ret != 0)
     {
         printf("%sinit sdk err ret:%d\n", ERROR_PREFIX.c_str(), ret);
+        // 初始化失败后不要留着半初始化的指针，否则后续任何调用都是崩溃
+        ::DestroySdk(this->sdk_);
+        this->sdk_ = nullptr;
+        this->sdk_destroyed_ = true;
         Napi::TypeError::New(info.Env(), "Init WeWorkFinance sdk error.")
             .ThrowAsJavaScriptException();
         return  -1;
@@ -113,9 +237,37 @@ int WeWorkChat::initSdk(const Napi::CallbackInfo& info){
     return 0;
 }
 
+bool WeWorkChat::ensureSdk(Napi::Env env) {
+    if (this->sdk_ == nullptr) {
+        Napi::Error::New(env, ERROR_PREFIX + "sdk unavailable: init failed or stopFetch() already released it")
+            .ThrowAsJavaScriptException();
+        return false;
+    }
+    return true;
+}
+
+void WeWorkChat::destroySdk() {
+    bool expected = false;
+    // 重复调用 stopFetch 会 double free sdk，用 CAS 保证只释放一次
+    if (this->sdk_ != nullptr && this->sdk_destroyed_.compare_exchange_strong(expected, true)) {
+        ::DestroySdk(this->sdk_);
+        this->sdk_ = nullptr;
+    }
+}
+
+void WeWorkChat::ReleaseFetchRef() {
+    this->Unref();
+}
+
 WeWorkChat::WeWorkChat(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<WeWorkChat>(info) {
         Napi::Env env = info.Env();
+
+        this->sdk_ = nullptr;
+        this->seq_ = 0;
+        this->end_ = false;
+        this->fetching_ = false;
+        this->sdk_destroyed_ = false;
 
         int length = info.Length();
 
@@ -125,25 +277,62 @@ WeWorkChat::WeWorkChat(const Napi::CallbackInfo& info)
         }
 
         Napi::Object obj = info[0].As<Napi::Object>();
-        //value.ToObject()
-        this->corpid_ = obj.Get("corpid").ToString();
-        this->secret_ = obj.Get("secret").ToString();
-        this->private_key_ = obj.Get("private_key").ToString();
-        this->seq_ = obj.Get("seq").ToNumber();
-        
-        
-        this->end_ = false;
+
+        // 必填参数缺失时直接报错，不要带着空的 corpid/secret 去 Init
+        const char *required[] = {"corpid", "secret", "private_key"};
+        for (const char *key : required) {
+            if (!obj.Has(key) || !obj.Get(key).IsString()) {
+                Napi::TypeError::New(env, std::string("Missing or invalid option: ") + key)
+                    .ThrowAsJavaScriptException();
+                return;
+            }
+        }
+
+        this->corpid_ = obj.Get("corpid").As<Napi::String>().Utf8Value();
+        this->secret_ = obj.Get("secret").As<Napi::String>().Utf8Value();
+        this->private_key_ = obj.Get("private_key").As<Napi::String>().Utf8Value();
+
+        int64_t seq = GetNumberOption(obj, "seq", 0);
+        this->seq_ = seq < 0 ? 0 : seq;
+
         this->initSdk(info);
+}
+
+WeWorkChat::~WeWorkChat() {
+    // 用户忘了调 stopFetch 时兜底释放 sdk。
+    this->end_ = true;
+    if (this->fetching_.load()) {
+        // 正常情况下 fetch 期间对象被 Ref 住不会走到这里，但进程/env 退出时
+        // 析构会被强制执行。此时后台线程可能还在用 sdk，宁可漏掉一次释放，
+        // 也不能让它拿到野指针。
+        return;
+    }
+    this->destroySdk();
 }
 
 
 Napi::Value WeWorkChat::EndFetchData(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
     this->end_ = true;
-    // sleep 一下，确保正在执行的线程执行完毕
-    std::this_thread::sleep_for(std::chrono::milliseconds(800));
+
+    // 必须等后台线程真正退出再 DestroySdk。原来只 sleep 800ms，而一次
+    // GetChatData 最长要等 30s，sdk 被提前释放后线程继续用它就是
+    // Segmentation fault (core dumped)。
+    int waited = 0;
+    while (this->fetching_.load() && waited < kStopWaitMs) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        waited += 50;
+    }
+
+    if (this->fetching_.load()) {
+        printf("%sstopFetch: fetch thread still running after %dms, skip DestroySdk\n",
+               ERROR_PREFIX.c_str(), waited);
+        return Napi::Number::New(env, static_cast<double>(this->seq_.load()));
+    }
+
     // sdk 由用户手动释放
-    DestroySdk(this->sdk_);
-    return Napi::Number::New(info.Env(), this->seq_);
+    this->destroySdk();
+    return Napi::Number::New(env, static_cast<double>(this->seq_.load()));
 }
 
 Napi::Value WeWorkChat::GetChat(const Napi::CallbackInfo& info){
@@ -153,22 +342,42 @@ Napi::Value WeWorkChat::GetChat(const Napi::CallbackInfo& info){
 
     if (length <= 0 || !info[0].IsObject()) {
         Napi::TypeError::New(env, "Expected one object argument").ThrowAsJavaScriptException();
+        // 编译时定义了 NAPI_DISABLE_CPP_EXCEPTIONS，ThrowAsJavaScriptException 不会中断
+        // C++ 执行流，这里不 return 的话下一行就会把非对象当对象用
+        return env.Null();
+    }
+
+    if (!this->ensureSdk(env)) {
+        return env.Null();
     }
 
     Napi::Object obj = info[0].As<Napi::Object>();
-   
-    std::string sdk_fileid = obj.Get("max_results").ToString();
-    std::int64_t seq = obj.Get("seq").ToNumber();
-    std::int64_t timeout = obj.Get("timeout").ToNumber();
-    if (!seq) seq= 0;
 
-    Slice_t *chatDatas = NewSlice();
+    // 之前这行把 max_results 读进了一个叫 sdk_fileid 且没人使用的字符串，
+    // 下面调用 GetChatData 时用的是常量 1000，所以传什么都没效果
+    int64_t max_results = GetNumberOption(obj, "max_results", kMaxResults);
+    if (max_results <= 0 || max_results > kMaxResults) {
+        max_results = kMaxResults;
+    }
+    std::int64_t seq = GetNumberOption(obj, "seq", 0);
+    if (seq < 0) seq = 0;
+    std::int64_t timeout = GetNumberOption(obj, "timeout", kDefaultTimeout);
+    if (timeout <= 0) timeout = kDefaultTimeout;
+
+    SliceGuard chatDatas;
+    if (!chatDatas.valid()) {
+        Napi::Error::New(env, ERROR_PREFIX + "NewSlice failed").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
     // getchatdata api
     const int numOfRetries = 3;
     int cnt = 1;
     int ret = 0;
     do {
-        ret = GetChatData(this->sdk_, seq, max_results, "", "", timeout, chatDatas);
+        ret = GetChatData(this->sdk_, static_cast<unsigned long long>(seq),
+                          static_cast<unsigned int>(max_results), "", "",
+                          static_cast<int>(timeout), chatDatas.get());
         if   (ret >= 10001 && ret <= 10003){
             //cout << "\t try number#" << cnt <<" fail \n";
             std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -177,17 +386,21 @@ Napi::Value WeWorkChat::GetChat(const Napi::CallbackInfo& info){
             break;
         }
     }while (cnt <= numOfRetries);
-    
+
     if (ret != 0)
     {
         printf("%sGetChatData err ret:%d\n",ERROR_PREFIX.c_str(), ret);
         char errMsg[256];
-        sprintf(errMsg, "%sGetChatData err ret:%d\n",ERROR_PREFIX.c_str(), ret);
+        snprintf(errMsg, sizeof(errMsg), "%sGetChatData err ret:%d",ERROR_PREFIX.c_str(), ret);
         Napi::Error::New(env, errMsg).ThrowAsJavaScriptException();
         return env.Null();
     }
 
-    char *data = GetContentFromSlice(chatDatas);
+    char *data = GetContentFromSlice(chatDatas.get());
+    if (data == nullptr) {
+        Napi::Error::New(env, ERROR_PREFIX + "GetContentFromSlice returned null").ThrowAsJavaScriptException();
+        return env.Null();
+    }
     // parse data
     rapidjson::Document doc;
     if (doc.Parse(data).HasParseError())
@@ -200,74 +413,102 @@ Napi::Value WeWorkChat::GetChat(const Napi::CallbackInfo& info){
     }
     if (doc.HasMember("errcode"))
     {
-        int errcode = doc["errcode"].GetInt();
+        int errcode = static_cast<int>(GetInt64Member(doc, "errcode", 0));
         if (errcode != 0)
         {
-            string errMsg = doc["errmsg"].GetString();
-            printf("%sget chat message error:%s.\n",ERROR_PREFIX.c_str(), errMsg.c_str());
-            Napi::Error::New(env, "get chat message error").ThrowAsJavaScriptException();
+            const char *errMsg = GetStringMember(doc, "errmsg", "unknown error");
+            printf("%sget chat message error:%s.\n",ERROR_PREFIX.c_str(), errMsg);
+            char msg[256];
+            snprintf(msg, sizeof(msg), "get chat message error, errcode:%d errmsg:%s", errcode, errMsg);
+            Napi::Error::New(env, msg).ThrowAsJavaScriptException();
             return env.Null();
         }
     }
 
-    const rapidjson::Value &chatData = doc["chatdata"];
-    Napi::Array data_array = Napi::Array::New(info.Env(), chatData.Size());
     Napi::Object retObj = Napi::Object::New(env);
-    
-    unsigned int dataSize =chatData.Size();
+
+    const rapidjson::Value *chatDataPtr = FindMember(doc, "chatdata");
+    if (chatDataPtr == nullptr || !chatDataPtr->IsArray()) {
+        // errcode 为 0 但没有 chatdata（比如已经拉到最新），按空结果返回，
+        // 不要让 doc["chatdata"] 在 Release 构建下直接崩掉
+        retObj.Set("last_seq", Napi::Number::New(env, 0));
+        retObj.Set("data", Napi::Array::New(env, 0));
+        return retObj;
+    }
+    const rapidjson::Value &chatData = *chatDataPtr;
+
+    unsigned int dataSize = chatData.Size();
+    Napi::Array data_array = Napi::Array::New(env, dataSize);
+
     int64_t last_seq = 0;
-    if (dataSize >0) {
-        last_seq =chatData[dataSize-1]["seq"].GetInt64();
+    if (dataSize > 0) {
+        last_seq = GetInt64Member(chatData[dataSize - 1], "seq", 0);
     }
     for (SizeType i = 0; i < dataSize; ++i)
     {
-        //cout << "current seq:" <<chatData[i]["seq"].GetInt64()<<endl;
-        string encryptRandomKey = chatData[i]["encrypt_random_key"].GetString();
-        //cout << "encrypt_random_key: " << encryptRandomKey << endl;
-        string encryptChatMsg = chatData[i]["encrypt_chat_msg"].GetString();
-        //cout << "encrypt_chat_msg: " << encryptChatMsg << endl;
+        const rapidjson::Value &item = chatData[i];
+        string encryptRandomKey = GetStringMember(item, "encrypt_random_key", "");
+        string encryptChatMsg = GetStringMember(item, "encrypt_chat_msg", "");
+        if (encryptRandomKey.empty() || encryptChatMsg.empty()) {
+            printf("%sskip malformed chatdata item, seq:%lld\n", ERROR_PREFIX.c_str(),
+                   static_cast<long long>(GetInt64Member(item, "seq", -1)));
+            continue;
+        }
         string encrypt_key = rsa_pri_decrypt(encryptRandomKey, this->private_key_.c_str());
-        //cout << "encrypt_key: " << encrypt_key << endl;
         if (encrypt_key.length()==0) {
+            LogDecryptKeyFailure(item);
             continue;
         }
-        Slice_t *slice_msg = NewSlice();
-        
-        int ret = DecryptData(encrypt_key.c_str(), encryptChatMsg.c_str(), slice_msg);
-        if (ret != 0){
-            cout << ERROR_PREFIX <<"Decrypt Data error:"<<ret<< endl;
+        SliceGuard slice_msg;
+        if (!slice_msg.valid()) {
+            printf("%sNewSlice failed\n", ERROR_PREFIX.c_str());
             continue;
         }
-  
-        
-        char *msg_data = GetContentFromSlice(slice_msg);
-        data_array[i] = Napi::String::New(info.Env(), msg_data);
-        FreeSlice(slice_msg);
+
+        int decRet = DecryptData(encrypt_key.c_str(), encryptChatMsg.c_str(), slice_msg.get());
+        if (decRet != 0){
+            cout << ERROR_PREFIX <<"Decrypt Data error:"<<decRet<< endl;
+            continue;
+        }
+
+        char *msg_data = GetContentFromSlice(slice_msg.get());
+        if (msg_data == nullptr) {
+            printf("%sGetContentFromSlice returned null\n", ERROR_PREFIX.c_str());
+            continue;
+        }
+        data_array[i] = Napi::String::New(env, msg_data);
     }
-    retObj.Set("last_seq", Napi::Number::New(env,last_seq));
+    retObj.Set("last_seq", Napi::Number::New(env, static_cast<double>(last_seq)));
     retObj.Set("data", data_array);
-    FreeSlice(chatDatas);
     return retObj;
 }
 
 void* WeWorkChat::fetchData(TsfnContext *context, void *this__) {
     WeWorkChat * this_ =  static_cast<WeWorkChat*>(this__);
-    
+
     while (true) {
-        if (this_->end_){
-            cout << "End fetch data:"<<this_->seq_<< endl;
+        if (this_->end_.load()){
+            cout << "End fetch data:"<<this_->seq_.load()<< endl;
             break;
         }
         // 微信限制频率为最高100ms/每次
         std::this_thread::sleep_for(std::chrono::milliseconds(150));
 
-        Slice_t *chatDatas = NewSlice();
+        SliceGuard chatDatas;
+        if (!chatDatas.valid()) {
+            printf("%sNewSlice failed\n", ERROR_PREFIX.c_str());
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+
         // getchatdata api
         const int numOfRetries = 3;
         int cnt = 1;
         int ret = 0;
         do {
-            ret = GetChatData(this_->sdk_, this_->seq_, max_results, "", "", 30, chatDatas);
+            ret = GetChatData(this_->sdk_, static_cast<unsigned long long>(this_->seq_.load()),
+                              static_cast<unsigned int>(kMaxResults), "", "",
+                              kFetchTimeout, chatDatas.get());
             if   (ret >= 10001 && ret <= 10003){
                 //cout << "\t try number#" << cnt <<" fail \n";
                 std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -276,30 +517,57 @@ void* WeWorkChat::fetchData(TsfnContext *context, void *this__) {
                 break;
             }
         }while (cnt <= numOfRetries);
-        
+
         if (ret != 0)
         {
             printf("%sGetChatData err ret:%d\n",ERROR_PREFIX.c_str(), ret);
+            // SliceGuard 析构会释放，之前这里 continue 会漏掉 FreeSlice，
+            // 每次错误响应泄漏一个 Slice_t，长时间运行会不断增长
             continue;
         }
-        
-        char *data = GetContentFromSlice(chatDatas);
-        
+
+        char *data = GetContentFromSlice(chatDatas.get());
+        if (data == nullptr) {
+            printf("%sGetContentFromSlice returned null\n", ERROR_PREFIX.c_str());
+            continue;
+        }
+
         int64_t seq = this_->parseJsonData(context,data);
         if (seq <0) {
             continue;
         }
-        
-        FreeSlice(chatDatas);
     }
-    
+
+    // 先标记线程已退出，stopFetch 看到这个标记后才会去 DestroySdk
+    this_->fetching_ = false;
     context->tsfn.Release();
     return 0;
 }
 
 Napi::Value WeWorkChat::StartFetchData(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
+
+    if (info.Length() <= 0 || !info[0].IsFunction()) {
+        Napi::TypeError::New(env, "Expected a callback function").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    if (!this->ensureSdk(env)) {
+        return env.Null();
+    }
+
+    // 重复调用会起多个线程同时改写 seq_，而且只有一个线程会被 join
+    if (this->fetching_.load()) {
+        Napi::Error::New(env, ERROR_PREFIX + "fetchData is already running, call stopFetch() first")
+            .ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    this->end_ = false;
+    this->fetching_ = true;
+
     auto tsContext = new TsfnContext(env);
+    tsContext->owner = this;
 
       // Create a new ThreadSafeFunction.
     tsContext->tsfn =
@@ -312,15 +580,26 @@ Napi::Value WeWorkChat::StartFetchData(const Napi::CallbackInfo& info) {
                                   FinalizerCallback, // Finalizer
                                   (void *)nullptr    // Finalizer data
           );
+
+    // 后台线程直接使用 this，期间必须阻止 JS 对象被 GC 回收，
+    // 否则线程会访问已释放的实例
+    this->Ref();
     tsContext->nativeThread = std::thread(fetchData, tsContext, this);
-    
+
     return tsContext->deferred.Promise();
 }
 
 int64_t WeWorkChat::parseJsonData(TsfnContext *context,const char *data){
     auto callback = [](Napi::Env env, Napi::Function jsCallback, MsgData *msg) {
-        jsCallback.Call({Napi::String::New(env, msg->msg_data)});
+        if (msg == nullptr) {
+            return;
+        }
+        // env 为空表示 tsfn 正在销毁，此时不能再回调 JS，但仍要把内存还回去
+        if (env != nullptr && msg->msg_data != nullptr) {
+            jsCallback.Call({Napi::String::New(env, msg->msg_data)});
+        }
         FreeSlice(msg->slice_msg);
+        delete msg;
     };
 
     rapidjson::Document doc;
@@ -333,58 +612,84 @@ int64_t WeWorkChat::parseJsonData(TsfnContext *context,const char *data){
     }
     if (doc.HasMember("errcode"))
     {
-        int errcode = doc["errcode"].GetInt();
+        int errcode = static_cast<int>(GetInt64Member(doc, "errcode", 0));
         if (errcode != 0)
         {
-            string errMsg = doc["errmsg"].GetString();
-            printf("%sget chat message error:%s.\n",ERROR_PREFIX.c_str(), errMsg.c_str());
+            printf("%sget chat message error:%s.\n",ERROR_PREFIX.c_str(),
+                   GetStringMember(doc, "errmsg", "unknown error"));
             return -1;
         }
     }
-    const rapidjson::Value &chatData = doc["chatdata"];
-  
+
+    const rapidjson::Value *chatDataPtr = FindMember(doc, "chatdata");
+    if (chatDataPtr == nullptr || !chatDataPtr->IsArray()) {
+        // 没有新消息时按空批次处理，不能直接 doc["chatdata"]
+        return this->seq_.load();
+    }
+    const rapidjson::Value &chatData = *chatDataPtr;
+
     for (SizeType i = 0; i < chatData.Size(); ++i)
     {
-        int64_t seq = chatData[i]["seq"].GetInt64();
-        this->mtx_.lock();
-        this->seq_ = seq;
-        // cout << "data seq: " << seq << endl;
-        this->mtx_.unlock();
-        string encryptRandomKey = chatData[i]["encrypt_random_key"].GetString();
-        //cout << "encrypt_random_key: " << encryptRandomKey << endl;
-        string encryptChatMsg = chatData[i]["encrypt_chat_msg"].GetString();
-        //cout << "encrypt_chat_msg: " << encryptChatMsg << endl;
-        string encrypt_key = rsa_pri_decrypt(encryptRandomKey, this->private_key_.c_str());
-        //cout << "encrypt_key: " << encrypt_key << endl;
-        if (encrypt_key.length()==0) {
+        // 一批最多 1000 条、每条 sleep 80ms，不检查 end_ 的话 stopFetch 之后
+        // 还要跑 80s 才停得下来
+        if (this->end_.load()) {
+            break;
+        }
+
+        const rapidjson::Value &item = chatData[i];
+        int64_t seq = GetInt64Member(item, "seq", -1);
+        if (seq < 0) {
+            printf("%sskip chatdata item without seq\n", ERROR_PREFIX.c_str());
             continue;
         }
-        Slice_t *slice_msg = NewSlice();
-        
-        int ret = DecryptData(encrypt_key.c_str(), encryptChatMsg.c_str(), slice_msg);
+        this->seq_ = seq;
+
+        string encryptRandomKey = GetStringMember(item, "encrypt_random_key", "");
+        string encryptChatMsg = GetStringMember(item, "encrypt_chat_msg", "");
+        if (encryptRandomKey.empty() || encryptChatMsg.empty()) {
+            printf("%sskip malformed chatdata item, seq:%lld\n", ERROR_PREFIX.c_str(),
+                   static_cast<long long>(seq));
+            continue;
+        }
+        string encrypt_key = rsa_pri_decrypt(encryptRandomKey, this->private_key_.c_str());
+        if (encrypt_key.length()==0) {
+            LogDecryptKeyFailure(item);
+            continue;
+        }
+        SliceGuard slice_msg;
+        if (!slice_msg.valid()) {
+            printf("%sNewSlice failed\n", ERROR_PREFIX.c_str());
+            continue;
+        }
+
+        int ret = DecryptData(encrypt_key.c_str(), encryptChatMsg.c_str(), slice_msg.get());
         if (ret != 0){
             cout << ERROR_PREFIX <<"Decrypt Data error:"<<ret<< endl;
             continue;
         }
-        //cout << "DecryptData ret: " << ret << endl;
-        //int64_t msg_len = GetSliceLen(slice_msg);
-        //cout << "msg_len: " << msg_len << endl;
-        
-        char *msg_data = GetContentFromSlice(slice_msg);
+
+        char *msg_data = GetContentFromSlice(slice_msg.get());
+        if (msg_data == nullptr) {
+            printf("%sGetContentFromSlice returned null\n", ERROR_PREFIX.c_str());
+            continue;
+        }
+
         MsgData *theData = new MsgData();
-        theData->msg_data =msg_data;
-        theData->slice_msg =slice_msg;
-        // 确保执行完 callback 再释放 slice_msg
+        theData->msg_data = msg_data;
+        // 所有权移交给回调：确保执行完 callback 再释放 slice_msg
+        theData->slice_msg = slice_msg.release();
+
         napi_status status =
             context->tsfn.BlockingCall(theData, callback);
-        
+
         if (status != napi_ok) {
-            FreeSlice(slice_msg);
+            FreeSlice(theData->slice_msg);
+            delete theData;
             Napi::Error::Fatal("parseJsonData", "Napi::ThreadSafeNapi::Function.BlockingCall() failed");
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(80));
     }
-    return this->seq_;
+    return this->seq_.load();
 }
 
 Napi::Value WeWorkChat::GetMediaData(const Napi::CallbackInfo& info) {
@@ -394,23 +699,40 @@ Napi::Value WeWorkChat::GetMediaData(const Napi::CallbackInfo& info) {
 
     if (length <= 0 || !info[0].IsObject()) {
         Napi::TypeError::New(env, "Expected one object argument").ThrowAsJavaScriptException();
+        // 同 GetChat，这里必须 return，否则下一行会把非对象当对象解引用
+        return env.Null();
+    }
+
+    if (!this->ensureSdk(env)) {
+        return env.Null();
     }
 
     Napi::Object obj = info[0].As<Napi::Object>();
-   
-    std::string sdk_fileid = obj.Get("sdk_fileid").ToString();
-    std::string index_buf = obj.Get("index_buf").ToString();
-    
+
+    std::string sdk_fileid = GetStringOption(obj, "sdk_fileid", "");
+    // index_buf 是可选参数，之前不传时 ToString() 会得到字面量 "undefined"
+    // 并被当成真实的分片索引传给 sdk
+    std::string index_buf = GetStringOption(obj, "index_buf", "");
+
+    if (sdk_fileid.empty()) {
+        Napi::TypeError::New(env, "Missing or invalid option: sdk_fileid").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
     Napi::Function cb;
     bool isCbFunction = false;
-    if (info[1].IsFunction()){
+    if (info.Length() > 1 && info[1].IsFunction()){
         cb = info[1].As<Napi::Function>();
         isCbFunction = true;
     }
-       
+
     // 记得释放
     MediaData_t* media = NewMediaData();
-    
+    if (media == nullptr) {
+        Napi::Error::New(env, ERROR_PREFIX + "NewMediaData failed").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
     const int numOfRetries = 3;
     int cnt = 1;
     int ret = 0;
@@ -424,7 +746,7 @@ Napi::Value WeWorkChat::GetMediaData(const Napi::CallbackInfo& info) {
             break;
         }
     }while (cnt <= numOfRetries);
-  
+
     if (ret != 0) {
         printf("%sGetMediaData err ret:%d\n",ERROR_PREFIX.c_str(), ret);
         ::FreeMediaData(media);
@@ -433,19 +755,30 @@ Napi::Value WeWorkChat::GetMediaData(const Napi::CallbackInfo& info) {
             return Napi::Number::New(env,-1);
         } else{
             char errMsg[128];
-            sprintf(errMsg, "Get media data error,errorcode:%d", ret);
+            snprintf(errMsg, sizeof(errMsg), "Get media data error,errorcode:%d", ret);
             Napi::Error::New(env, errMsg).ThrowAsJavaScriptException();
             return env.Null();
         }
-        
+
     }
-    //int media_data_len = ::GetDataLen(media);
-    //int index_len = ::GetIndexLen(media);
-     
-    //printf("content size:%d isfin:%d outindex:%s index_len:%d\n",media_data_len, is_finish,out_index_buf,index_len);
-    //char* media_data = ::GetData(media);
+
+    char *media_data = ::GetData(media);
+    int media_data_len = ::GetDataLen(media);
+    if (media_data == nullptr || media_data_len < 0) {
+        printf("%sGetMediaData returned empty buffer\n", ERROR_PREFIX.c_str());
+        ::FreeMediaData(media);
+        if (isCbFunction){
+            cb.Call(env.Global(), {Napi::String::New(env, "GetMediaData returned empty buffer")});
+            return Napi::Number::New(env,-1);
+        }
+        Napi::Error::New(env, ERROR_PREFIX + "GetMediaData returned empty buffer").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
     std:: string out_index_buf = "";
-    Napi::ArrayBuffer buf_data = Napi::ArrayBuffer::New(env, GetData(media), GetDataLen(media),MediaDataFinalizerCallback,media);
+    // ArrayBuffer 接管 media 的生命周期，由 MediaDataFinalizerCallback 释放
+    Napi::ArrayBuffer buf_data = Napi::ArrayBuffer::New(env, media_data, static_cast<size_t>(media_data_len),
+                                                       MediaDataFinalizerCallback, media);
     bool is_finish;
     if(IsMediaDataFinish(media)==1)
     {
@@ -453,10 +786,11 @@ Napi::Value WeWorkChat::GetMediaData(const Napi::CallbackInfo& info) {
         out_index_buf = "";
        //break;
     } else {
-        out_index_buf = ::GetOutIndexBuf(media);
+        const char *next_index = ::GetOutIndexBuf(media);
+        out_index_buf = next_index == nullptr ? "" : next_index;
         is_finish = false;
     }
-    
+
     Napi::Object retObj = Napi::Object::New(env);
     retObj.Set("is_finished", Napi::Boolean::New(env,is_finish));
     retObj.Set("buf_index",Napi::String::New(env,out_index_buf));
@@ -468,7 +802,7 @@ Napi::Value WeWorkChat::GetMediaData(const Napi::CallbackInfo& info) {
     } else{
         return retObj;
     }
-    
+
 }
 
 
@@ -488,10 +822,17 @@ std::string rsa_pri_decrypt(const std::string &cipherText,const char *priKey)
     if(rsa == NULL)
     {
         printf("%sFailed to create RSA.\n",ERROR_PREFIX.c_str());
+        BIO_free_all(keybio);
         return "";
     }
     int len = RSA_size(rsa);
     char *decryptedText = (char *)malloc(len + 1);
+    if (decryptedText == NULL)
+    {
+        BIO_free_all(keybio);
+        RSA_free(rsa);
+        return "";
+    }
     memset(decryptedText, 0, len + 1);
 
     // 解密函数
@@ -533,4 +874,3 @@ std::string decode64(const std::string &ascdata)
    }
    return retval;
 }
-


### PR DESCRIPTION
一次性处理 issue #1 #2 #4 #5 #6 #7 #8 和 PR #3。

## 修复内容

### `max_results` 不生效 (#5)
`GetChat` 里这行把参数读进了一个叫 `sdk_fileid`、且后面没人使用的字符串：

```cpp
std::string sdk_fileid = obj.Get("max_results").ToString();
```

真正调用 `GetChatData` 时用的是文件作用域常量 `max_results = 1000`，同名遮蔽让这个 bug 很难一眼看出来。现在正确读取参数并限制在 `1~1000`，常量也改名为 `kMaxResults` 避免再次遮蔽。

`timeout` / `seq` 一并改为按缺省值处理 —— 之前对 `undefined` 调 `ToNumber()` 得到 `NaN`，再转 `int64_t` 是未定义行为。

### `Slice_t` 泄漏 (#7 #8)
两处都属实：`GetChat` 的三个错误返回分支、`fetchData` 轮询循环的两个 `continue` 分支，都跳过了 `FreeSlice`。因为 `FreeSlice` 只写在成功路径末尾，任何错误响应都会漏一个。`fetchData` 是长驻轮询，后端间歇性报错就会无上限增长。

改成 RAII (`SliceGuard`)，`NewSlice` 的所有出口都会配对释放；需要交给 tsfn 回调释放的那一个通过 `release()` 转移所有权。顺带补上了 `MsgData` 一直没有 `delete` 的泄漏。

### Segmentation fault (#6)
排查出几处都会 core dump 的地方：

- **`stopFetch` 提前释放 sdk**。之前只 `sleep 800ms` 就 `DestroySdk`，而一次 `GetChatData` 最长要等 30s；更糟的是一批 1000 条消息、每条 `sleep 80ms`，光分发就要 80s。后台线程会继续使用已经被释放的 sdk。现在会等线程真正退出再释放，并在消息循环里检查 `end_` 以便快速停下。
- **重复调用 `stopFetch` 把 sdk double free**，现在用 CAS 保证只释放一次。
- **rapidjson 在 Release 构建（`NDEBUG`）下 `operator[]` 不做成员存在性检查**，服务端少返回一个字段（比如没有 `chatdata`）就是野指针解引用。所有字段读取改走 `FindMember`。
- **`ThrowAsJavaScriptException` 不会中断 C++ 执行流**（编译时定义了 `NAPI_DISABLE_CPP_EXCEPTIONS`）。参数校验失败后原来没有 `return`，下一行 `info[0].As<Napi::Object>()` 直接把非对象当对象用。
- **`initSdk` 失败后留下半初始化的 sdk 指针**，后续任何调用都会崩；现在会清空并在调用时抛出明确错误。
- **后台线程直接持有 `this`**，JS 对象被 GC 回收后就是 use-after-free。fetch 期间改为 `Ref()` 持有，线程结束后在 finalizer 里 `Unref()`。
- **重复调用 `fetchData`** 会起多个线程同时改写 `seq_`，而且只有一个会被 join，现在直接报错。

### 编译报错 (#4)
`binding.gyp` 显式固定 `OPENSSL_API_COMPAT=0x10100000L`，避免 API 兼容级别由不匹配的 node 头文件推导出来。附带效果是 OpenSSL 3.0 下 `RSA_*` 的 deprecated 告警全部消失（编译从 6 个告警变为 0 个）。

### 解密失败时输出 publickey_ver (取自 PR #3)
私钥版本对不上是解密失败最常见的原因，而之前这里是静默 `continue`。现在会打印该条消息的 `seq` 和 `publickey_ver`，提示换用对应版本的私钥。思路来自 @gcxfd 的 PR #3，但**不打印 `private_key`** —— 原改动所在的那段调试代码会把私钥写进日志。

### 其它
- `getMediaData` 的可选参数 `index_buf` 不传时，`ToString()` 会得到字面量 `"undefined"` 并被当成真实的分片索引传给 sdk。
- `sprintf` → `snprintf`。
- `rsa_pri_decrypt` 提前返回时补上 `BIO_free_all`。
- README 补充常见问题，`index.d.ts` 同步修正（可选参数、`last_seq` 为空批次时是 `0`、`data` 可能含空值）。

## 验证情况

`wework.cc` / `main.cc` 用 binding.gyp 相同的 defines 完整编译通过，**0 warning 0 error**。

**但没有做 Linux 下的链接与运行时验证** —— 本机是 macOS，企业微信只提供 Linux 的 `.so`，本地 Docker 也起不来。合并前建议在 Linux 上跑一次 `npm run build` 确认链接通过。